### PR TITLE
Implementing dark and light mode for google maps.

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@wild-siena/google-maps",
+  "name": "@wild-siena/google-maps-bundle",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@wild-siena/google-maps",
+      "name": "@wild-siena/google-maps-bundle",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -14,6 +14,10 @@
       },
       "devDependencies": {
         "esbuild": "0.21.5"
+      },
+      "peerDependencies": {
+        "@googlemaps/js-api-loader": "^1.16.6",
+        "@hotwired/stimulus": "^3.2.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -408,13 +412,10 @@
       }
     },
     "node_modules/@googlemaps/js-api-loader": {
-      "version": "1.16.6",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.6.tgz",
-      "integrity": "sha512-V8p5W9DbPQx74jWUmyYJOerhiB4C+MHekaO0ZRmc6lrOYrvY7+syLhzOWpp55kqSPeNb+qbC2h8i69aLIX6krQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      }
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.8.tgz",
+      "integrity": "sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@hotwired/stimulus": {
       "version": "3.2.2",
@@ -460,12 +461,6 @@
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
       }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
     }
   }
 }

--- a/docs/map_options_reference.md
+++ b/docs/map_options_reference.md
@@ -47,7 +47,8 @@ When set to ``true`` you see the Pegman control that can be dragged and dropped 
 
 **rotateControl**: bool (optional)
 
-When set to ``true`` you see the Button where you can change tilt and rotate options for maps containing oblique imagery.
+When set to ``true`` you see the Button where you can change tilt and rotate options for maps containing oblique
+imagery.
 
 **fullscreenControl**: bool (optional)
 
@@ -65,6 +66,12 @@ You can set the gestureHandling to four different values.
 ``GestureType::COOPERATIVE``, ``GestureType::AUTO``, ``GestureType::GREEDY``, ``GestureType::NONE``
 With this property you can change the zoom behavior when scrolling.
 
+**colorScheme**: ColorSchemeType (optional)
+
+You can set the colorScheme to three different values.
+``ColorSchemeType::LIGHT``, ``ColorSchemeType::DARK``, ``ColorSchemeType::FOLLOW_SYSTEM``
+With this property you can change light or dark mode of a map. This is only possible for the map type ``terrain`` and
+``roadmap``.
 
 
 
@@ -72,6 +79,7 @@ Examples
 --------
 
 Create a new MapOptions instance.
+
 ```php
 use WildSiena\GoogleMapsBundle\Model\MapOptions;
 
@@ -79,6 +87,7 @@ new MapOptions(center: new LatLng(lat: 42.42, lng: 42.42), zoom: 7);
 ```
 
 Create a new MapOptions instance with mapId.
+
 ```php
 use WildSiena\GoogleMapsBundle\Model\MapOptions;
 
@@ -87,6 +96,7 @@ $mapOptions->setMapId("DEMO_MAP_ID");
 ```
 
 Create a new MapOptions instance with disabled default ui.
+
 ```php
 use WildSiena\GoogleMapsBundle\Model\MapOptions;
 
@@ -172,4 +182,14 @@ use WildSiena\GoogleMapsBundle\Enum\GestureType;
 
 $mapOptions = new MapOptions(center: new LatLng(lat: 42.42, lng: 42.42), zoom: 7);
 $mapOptions->setGestureHandling(GestureType::COOPERATIVE);
+```
+
+Create a new MapOptions instance with colorScheme set to DARK.
+
+```php
+use WildSiena\GoogleMapsBundle\Model\MapOptions;
+use WildSiena\GoogleMapsBundle\Enum\ColorSchemeType;
+
+$mapOptions = new MapOptions(center: new LatLng(lat: 42.42, lng: 42.42), zoom: 7);
+$mapOptions->setColorScheme(ColorSchemeType::DARK);
 ```

--- a/src/Enum/ColorSchemeType.php
+++ b/src/Enum/ColorSchemeType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WildSiena\GoogleMapsBundle\Enum;
+
+enum ColorSchemeType: string
+{
+    case LIGHT = "LIGHT";
+    case DARK = "DARK";
+    case FOLLOW_SYSTEM = "FOLLOW_SYSTEM";
+}

--- a/src/Model/MapOptions.php
+++ b/src/Model/MapOptions.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace WildSiena\GoogleMapsBundle\Model;
 
+use WildSiena\GoogleMapsBundle\Enum\ColorSchemeType;
 use WildSiena\GoogleMapsBundle\Enum\GestureType;
 use WildSiena\GoogleMapsBundle\Enum\MapType;
 
@@ -18,6 +19,7 @@ class MapOptions
     protected bool $fullscreenControl;
     protected MapType $mapTypeId;
     protected GestureType $gestureHandling;
+    protected ColorSchemeType $colorScheme;
 
     /**
      * @param LatLng $center
@@ -243,6 +245,24 @@ class MapOptions
     public function setGestureHandling(GestureType $gestureHandling): MapOptions
     {
         $this->gestureHandling = $gestureHandling;
+        return $this;
+    }
+
+    /**
+     * @return ColorSchemeType
+     */
+    public function getColorScheme(): ColorSchemeType
+    {
+        return $this->colorScheme;
+    }
+
+    /**
+     * @param ColorSchemeType $colorScheme
+     * @return MapOptions
+     */
+    public function setColorScheme(ColorSchemeType $colorScheme): MapOptions
+    {
+        $this->colorScheme = $colorScheme;
         return $this;
     }
 

--- a/tests/GoogleMapExpected.php
+++ b/tests/GoogleMapExpected.php
@@ -68,6 +68,11 @@ class GoogleMapExpected
         return self::getValue('{"center":{"lat":-43.0,"lng":29.2},"zoom":7,"gestureHandling":"cooperative"}');
     }
 
+    private static function getMapOptionsValueWithColorSchemeDark(): string
+    {
+        return self::getValue('{"center":{"lat":-43.0,"lng":29.2},"zoom":7,"colorScheme":"DARK"}');
+    }
+
     public static function getGoogleMapAttrExpected(): string
     {
         return self::getAttr(
@@ -123,6 +128,14 @@ class GoogleMapExpected
         return self::getAttr(
             self::getLoaderOptionsValue(),
             self::getMapOptionsValueWithGestureHandlingCooperative()
+        );
+    }
+
+    public static function getGoogleMapAttrWithColorSchemeDark(): string
+    {
+        return self::getAttr(
+            self::getLoaderOptionsValue(),
+            self::getMapOptionsValueWithColorSchemeDark()
         );
     }
 

--- a/tests/GoogleMapFactory.php
+++ b/tests/GoogleMapFactory.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace WildSiena\GoogleMapsBundle\Tests;
 
+use WildSiena\GoogleMapsBundle\Enum\ColorSchemeType;
 use WildSiena\GoogleMapsBundle\Enum\GestureType;
 use WildSiena\GoogleMapsBundle\Enum\MapType;
 use WildSiena\GoogleMapsBundle\Model\GoogleMap;
@@ -104,6 +105,15 @@ class GoogleMapFactory
         return self::createGoogleMap(
             self::createMapOptions()
                 ->setGestureHandling(GestureType::COOPERATIVE),
+            null
+        );
+    }
+
+    public static function getGoogleMapWithColorSchemeDark(): GoogleMap
+    {
+        return self::createGoogleMap(
+            self::createMapOptions()
+                ->setColorScheme(ColorSchemeType::DARK),
             null
         );
     }

--- a/tests/Twig/GoogleMapsExtensionTest.php
+++ b/tests/Twig/GoogleMapsExtensionTest.php
@@ -62,6 +62,11 @@ class GoogleMapsExtensionTest extends TestCase
                 [],
                 GoogleMapExpected::getGoogleMapAttrWithGestureHandlingCooperative()
             ],
+            'color scheme set to dark' => [
+                GoogleMapFactory::getGoogleMapWithColorSchemeDark(),
+                [],
+                GoogleMapExpected::getGoogleMapAttrWithColorSchemeDark()
+            ],
         ];
     }
 
@@ -94,6 +99,10 @@ class GoogleMapsExtensionTest extends TestCase
             'gestureHandling set to cooperative' => [
                 GoogleMapFactory::getGoogleMapWithGestureHandlingCooperative(),
                 GoogleMapExpected::getGoogleMapAttrWithGestureHandlingCooperative()
+            ],
+            'color scheme set to dark' => [
+                GoogleMapFactory::getGoogleMapWithColorSchemeDark(),
+                GoogleMapExpected::getGoogleMapAttrWithColorSchemeDark()
             ],
         ];
     }


### PR DESCRIPTION
- Add new enum for handling the dark, light and follow_system.
- Integreate color scheme into the google maps options.
- Update js dependencies.